### PR TITLE
Automatically generate netlists

### DIFF
--- a/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
+++ b/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
@@ -416,6 +416,9 @@ public class FEntwumSNetlistReaderFrontendModule : IModule
 
         logger.Log("FEntwumS.NetlistViewer: Subscribed relevant services to the settings relevant to them");
 
+        logger.Log("Starting the backend");
+        _ = ServiceManager.GetService<FrontendService>().StartBackendIfNotStartedAsync();
+
         ServiceManager.GetService<IApplicationStateService>().RegisterShutdownAction(() =>
         {
             try

--- a/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
+++ b/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
@@ -211,6 +211,7 @@ public class FEntwumSNetlistReaderFrontendModule : IModule
         containerRegistry.RegisterSingleton<IHierarchyJsonParser, HierarchyJsonParser>();
         containerRegistry.RegisterSingleton<IHierarchyInformationService, HierarchyInformationService>();
         containerRegistry.RegisterSingleton<IStorageService, StorageService>();
+        containerRegistry.RegisterSingleton<IProjectMonitor, ProjectMonitor>();
     }
 
     public void OnInitialized(IContainerProvider? containerProvider)
@@ -407,6 +408,7 @@ public class FEntwumSNetlistReaderFrontendModule : IModule
         ServiceManager.GetService<IFpgaBbService>().SubscribeToSettings();
         ServiceManager.GetService<IYosysService>().SubscribeToSettings();
         ServiceManager.GetService<INetlistGenerator>().SubscribeToSettings();
+        ServiceManager.GetService<IProjectMonitor>().SubscribeToSettings();
 
         logger.Log("FEntwumS.NetlistViewer: Subscribed relevant services to the settings relevant to them");
 

--- a/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
+++ b/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
@@ -376,7 +376,9 @@ public class FEntwumSNetlistReaderFrontendModule : IModule
         settingsService.RegisterSetting("Netlist Viewer", "Experimental", FentwumSNetlistViewerSettingsHelper.EnableHierarchyViewKey,
             new CheckBoxSetting("Enable hierarchy view", false));
         settingsService.RegisterSetting("Netlist Viewer", "Experimental", FentwumSNetlistViewerSettingsHelper.AutomaticNetlistGenerationKey,
-            new ComboBoxSetting("Automatic netlist generation", "Never", ["Never", "Always", "Every 5 minutes"]));
+            new ComboBoxSetting("Automatic netlist generation", "Never", ["Never", "Always", "Interval"]));
+        settingsService.RegisterSetting("Netlist Viewer", "Experimental", FentwumSNetlistViewerSettingsHelper.AutomaticNetlistGenerationIntervalKey,
+            new SliderSetting("Automatic netlist generation interval (s)", 60.0d, 15.0d, 3600.0d, 5.0d));
 
         logger.Log("FEntwumS.NetlistViewer: Registered custom settings");
 

--- a/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
+++ b/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
@@ -375,6 +375,8 @@ public class FEntwumSNetlistReaderFrontendModule : IModule
             new CheckBoxSetting("Always regenerate netlists", true));
         settingsService.RegisterSetting("Netlist Viewer", "Experimental", FentwumSNetlistViewerSettingsHelper.EnableHierarchyViewKey,
             new CheckBoxSetting("Enable hierarchy view", false));
+        settingsService.RegisterSetting("Netlist Viewer", "Experimental", FentwumSNetlistViewerSettingsHelper.AutomaticNetlistGenerationKey,
+            new ComboBoxSetting("Automatic netlist generation", "Never", ["Never", "Always", "Every 5 minutes"]));
 
         logger.Log("FEntwumS.NetlistViewer: Registered custom settings");
 

--- a/src/FEntwumS.NetlistViewer/Helpers/FentwumSNetlistViewerSettingsHelper.cs
+++ b/src/FEntwumS.NetlistViewer/Helpers/FentwumSNetlistViewerSettingsHelper.cs
@@ -46,6 +46,7 @@ public class FentwumSNetlistViewerSettingsHelper
     public static readonly string PerformanceTargetKey = "NetlistViewer_PerformanceTarget";
     public static readonly string AlwaysRegenerateNetlistsKey = "NetlistViewer_AlwaysRegenerateNetlists";
     public static readonly string EnableHierarchyViewKey = "NetlistViewer_EnableHierarchyView";
+    public static readonly string AutomaticNetlistGenerationKey = "NetlistViewer_AutomaticNetlistGeneration";
 
     #endregion
     

--- a/src/FEntwumS.NetlistViewer/Helpers/FentwumSNetlistViewerSettingsHelper.cs
+++ b/src/FEntwumS.NetlistViewer/Helpers/FentwumSNetlistViewerSettingsHelper.cs
@@ -4,8 +4,13 @@ namespace FEntwumS.NetlistViewer.Helpers;
 
 public class FentwumSNetlistViewerSettingsHelper
 {
+    #region Message Channel IDs
+
     public static readonly int HierarchyMessageChannel = 1;
     public static readonly int NetlistMessageChannel = 2;
+    public static readonly int ProjectChangedMessageChannel = 3;
+
+    #endregion
 
     public static readonly string ExpectedSettingsVersion = "1";
     

--- a/src/FEntwumS.NetlistViewer/Helpers/FentwumSNetlistViewerSettingsHelper.cs
+++ b/src/FEntwumS.NetlistViewer/Helpers/FentwumSNetlistViewerSettingsHelper.cs
@@ -21,6 +21,7 @@ public class FentwumSNetlistViewerSettingsHelper
                 : Environment.SpecialFolder.ApplicationData), "FEntwumSNetlistViewer");
     public static readonly string DataFilePath = Path.Combine(DataDirectory, "data.json");
     public static readonly string FentwumsSettingVersionKey = "Extension_SettingsVersion";
+    public static readonly string NetlistGenerationSettingsChangedKey = "NetlistGenerationSettingsChanged";
 
     #region Settings keys
 

--- a/src/FEntwumS.NetlistViewer/Helpers/FentwumSNetlistViewerSettingsHelper.cs
+++ b/src/FEntwumS.NetlistViewer/Helpers/FentwumSNetlistViewerSettingsHelper.cs
@@ -47,6 +47,7 @@ public class FentwumSNetlistViewerSettingsHelper
     public static readonly string AlwaysRegenerateNetlistsKey = "NetlistViewer_AlwaysRegenerateNetlists";
     public static readonly string EnableHierarchyViewKey = "NetlistViewer_EnableHierarchyView";
     public static readonly string AutomaticNetlistGenerationKey = "NetlistViewer_AutomaticNetlistGeneration";
+    public static readonly string AutomaticNetlistGenerationIntervalKey = "NetlistViewer_AutomaticNetlistGenerationInterval";
 
     #endregion
     

--- a/src/FEntwumS.NetlistViewer/Helpers/FentwumSNetlistViewerSettingsHelper.cs
+++ b/src/FEntwumS.NetlistViewer/Helpers/FentwumSNetlistViewerSettingsHelper.cs
@@ -12,7 +12,7 @@ public class FentwumSNetlistViewerSettingsHelper
 
     #endregion
 
-    public static readonly string ExpectedSettingsVersion = "1";
+    public static readonly string ExpectedSettingsVersion = "2";
     
     public static readonly string DataDirectory = Path.Combine(
         Environment.GetFolderPath(

--- a/src/FEntwumS.NetlistViewer/Helpers/SettingsUpgrader.cs
+++ b/src/FEntwumS.NetlistViewer/Helpers/SettingsUpgrader.cs
@@ -26,6 +26,15 @@ public class SettingsUpgrader
         {
             settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.EnableHierarchyViewKey, true);
         }
+
+        if (currentSettingsVersion <= 1)
+        {
+            if (settingsService.GetSettingValue<string>(FentwumSNetlistViewerSettingsHelper
+                    .AutomaticNetlistGenerationKey) == "Every 5 minutes")
+            {
+                settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.AutomaticNetlistGenerationKey, "Interval");
+            }
+        }
         
         storageService.SetKeyValuePairValue(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey, FentwumSNetlistViewerSettingsHelper.ExpectedSettingsVersion);
         await storageService.SaveAsync();

--- a/src/FEntwumS.NetlistViewer/Services/FrontendService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/FrontendService.cs
@@ -419,21 +419,27 @@ public class FrontendService : IFrontendService
 
     public async Task CreateVhdlNetlistAsync(IProjectFile vhdl)
     {
-        await ShowViewerAsync((await GenerateNetlistAsync(vhdl, NetlistType.VHDL))!);
+        await ShowViewerAsync(await GenerateNetlistAsync(vhdl, NetlistType.VHDL));
     }
 
     public async Task CreateVerilogNetlistAsync(IProjectFile verilog)
     {
-        await ShowViewerAsync((await GenerateNetlistAsync(verilog, NetlistType.Verilog))!);
+        await ShowViewerAsync(await GenerateNetlistAsync(verilog, NetlistType.Verilog));
     }
 
     public async Task CreateSystemVerilogNetlistAsync(IProjectFile sVerilog)
     {
-        await ShowViewerAsync((await GenerateNetlistAsync(sVerilog, NetlistType.System_Verilog))!);
+        await ShowViewerAsync(await GenerateNetlistAsync(sVerilog, NetlistType.System_Verilog));
     }
 
-    public async Task ShowViewerAsync(IProjectFile json)
+    public async Task ShowViewerAsync(IProjectFile? json)
     {
+        if (json is null)
+        {
+            _logger.Error("No netlist was generated");
+            return;
+        }
+        
         ApplicationProcess proc = _applicationStateService.AddState("Starting viewer", AppState.Loading);
 
         HttpResponseMessage? resp = null;

--- a/src/FEntwumS.NetlistViewer/Services/IFpgaBbService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/IFpgaBbService.cs
@@ -2,7 +2,7 @@
 
 namespace FEntwumS.NetlistViewer.Services;
 
-public interface IFpgaBbService : SettingsSubscriber
+public interface IFpgaBbService : ISettingsSubscriber
 {
     public string getBbCommand(IProjectFile? root = null);
 }

--- a/src/FEntwumS.NetlistViewer/Services/IFrontendService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/IFrontendService.cs
@@ -3,7 +3,7 @@ using OneWare.Essentials.Models;
 
 namespace FEntwumS.NetlistViewer.Services;
 
-public interface IFrontendService : SettingsSubscriber
+public interface IFrontendService : ISettingsSubscriber
 {
     public Task CreateVhdlNetlistAsync(IProjectFile vhdl);
 

--- a/src/FEntwumS.NetlistViewer/Services/INetlistGenerator.cs
+++ b/src/FEntwumS.NetlistViewer/Services/INetlistGenerator.cs
@@ -3,7 +3,7 @@ using OneWare.Essentials.Models;
 
 namespace FEntwumS.NetlistViewer.Services;
 
-public interface INetlistGenerator: SettingsSubscriber
+public interface INetlistGenerator: ISettingsSubscriber
 {
     public Task<bool> GenerateVhdlNetlistAsync(IProjectFile vhdlProject);
     public Task<bool> GenerateVerilogNetlistAsync(IProjectFile verilogProject);

--- a/src/FEntwumS.NetlistViewer/Services/IProjectMonitor.cs
+++ b/src/FEntwumS.NetlistViewer/Services/IProjectMonitor.cs
@@ -1,0 +1,6 @@
+﻿namespace FEntwumS.NetlistViewer.Services;
+
+public interface IProjectMonitor: ISettingsSubscriber
+{
+    
+}

--- a/src/FEntwumS.NetlistViewer/Services/ISettingsSubscriber.cs
+++ b/src/FEntwumS.NetlistViewer/Services/ISettingsSubscriber.cs
@@ -1,6 +1,6 @@
 ﻿namespace FEntwumS.NetlistViewer.Services;
 
-public interface SettingsSubscriber
+public interface ISettingsSubscriber
 {
     public void SubscribeToSettings();
 }

--- a/src/FEntwumS.NetlistViewer/Services/IYosysService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/IYosysService.cs
@@ -2,7 +2,7 @@
 
 namespace FEntwumS.NetlistViewer.Services;
 
-public interface IYosysService : SettingsSubscriber
+public interface IYosysService : ISettingsSubscriber
 {
     Task<bool> LoadVhdlAsync(IProjectFile file);
     Task<bool> LoadVerilogAsync(IProjectFile file);

--- a/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
+++ b/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
@@ -217,7 +217,11 @@ public class NetlistGenerator : INetlistGenerator
             return;
         }
         
-        // TODO check whether an HDL source file changed. Only then should the project be added to the queue
+        // Only add project to regeneration queue if a supported HDL source file has changed
+        if (Path.GetExtension(e.FullPath) is not (".vhdl" or ".vhd" or ".v" or ".sv"))
+        {
+            return;
+        }
         
         if (sender is FileSystemWatcher watcher)
         {

--- a/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
+++ b/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
@@ -214,8 +214,30 @@ public class NetlistGenerator : INetlistGenerator
     {
         if (sender is FileSystemWatcher watcher)
         {
-            _logger.Log($"Sender: {watcher.Path}");
+            IEnumerable<IProjectRoot> candidates = _projectExplorerService.Projects.Where(project => watcher.Path == project.FullPath);
+            List<IProjectRoot> candidatesList = candidates.ToList();
+
+            UniversalProjectRoot? projectCandidate = candidatesList.FirstOrDefault(x => x is UniversalProjectRoot) as UniversalProjectRoot;
+            
+            if (projectCandidate is null)
+            {
+                _logger.Error($"Project {e.FullPath} was not found");
+            }
+            else
+            {
+                lock (_lock)
+                {
+                    _changedProjectSet.Add(projectCandidate);
+                }
+                
+                
+            }
         }
+    }
+
+    private void ProcessQueue()
+    {
+        
     }
 
     public void SubscribeToSettings()

--- a/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
+++ b/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
@@ -24,6 +24,7 @@ public class NetlistGenerator : INetlistGenerator
     private List<FileSystemWatcher> _watchers = new();
     private readonly Lock _lock = new();
     private HashSet<UniversalProjectRoot> _changedProjectSet = new();
+    private AutomaticNetlistGenerationType _generationType = AutomaticNetlistGenerationType.Never;
 
     public NetlistGenerator()
     {
@@ -221,5 +222,18 @@ public class NetlistGenerator : INetlistGenerator
     {
         _settingsService.GetSettingObservable<bool>(FentwumSNetlistViewerSettingsHelper.AlwaysRegenerateNetlistsKey)
             .Subscribe((x) => _alwaysRegenerateNetlists = x);
+        
+        _settingsService.GetSettingObservable<string>(FentwumSNetlistViewerSettingsHelper.AutomaticNetlistGenerationKey).Subscribe(
+            x =>
+            {
+                _generationType = x switch
+                {
+                    "Never" => AutomaticNetlistGenerationType.Never,
+                    "Always" => AutomaticNetlistGenerationType.Always,
+                    "Interval" => AutomaticNetlistGenerationType.Interval,
+                    _ => AutomaticNetlistGenerationType.Never,
+                };
+
+            });
     }
 }

--- a/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
+++ b/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
@@ -10,7 +10,6 @@ namespace FEntwumS.NetlistViewer.Services;
 public class NetlistGenerator : INetlistGenerator
 {
     private static readonly ICustomLogger _logger;
-    private static readonly IApplicationStateService _applicationStateService;
     private static readonly ISettingsService _settingsService;
     
     private bool _alwaysRegenerateNetlists = true;
@@ -18,7 +17,6 @@ public class NetlistGenerator : INetlistGenerator
     static NetlistGenerator()
     {
         _logger = ServiceManager.GetCustomLogger();
-        _applicationStateService = ServiceManager.GetService<IApplicationStateService>();
         _settingsService = ServiceManager.GetService<ISettingsService>();
     }
     

--- a/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
+++ b/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
@@ -68,9 +68,14 @@ public class NetlistGenerator : INetlistGenerator
         return await GenerateVerilogNetlistAsync(systemVerilogProject);
     }
 
-    public async Task<(IProjectFile? netlistFile, bool success)> GenerateNetlistAsync(IProjectFile projectFile,
+    public async Task<(IProjectFile? netlistFile, bool success)> GenerateNetlistAsync(IProjectFile? projectFile,
         NetlistType netlistType)
     {
+        if (projectFile is null)
+        {
+            return (null, false);
+        }
+        
         bool success;
         IProjectFile? netlistFile;
 
@@ -297,7 +302,7 @@ public class NetlistGenerator : INetlistGenerator
             // DockService.Show inside the GhdlService
             await Dispatcher.UIThread.InvokeAsync(async () =>
             {
-                await GenerateNetlistAsync(projectRoot.Files.First(), netlistType);
+                await GenerateNetlistAsync((IProjectFile?) projectRoot.TopEntity, netlistType);
             });
         }
     }

--- a/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
+++ b/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Threading;
+using DynamicData.Binding;
 using FEntwumS.NetlistViewer.Helpers;
 using FEntwumS.NetlistViewer.Types;
 using OneWare.Essentials.Models;
@@ -29,6 +30,12 @@ public class NetlistGenerator : INetlistGenerator
         _logger = ServiceManager.GetCustomLogger();
         _settingsService = ServiceManager.GetService<ISettingsService>();
         _projectExplorerService = ServiceManager.GetService<IProjectExplorerService>();
+        
+        // Add or remove watchers as necessary when loaded projects list changes
+        _projectExplorerService.Projects.CollectionChanged += (sender, args) =>
+        {
+            setupWatchers();
+        };
     }
 
     public async Task<bool> GenerateVhdlNetlistAsync(IProjectFile vhdlProject)
@@ -196,6 +203,8 @@ public class NetlistGenerator : INetlistGenerator
                         _logger.Error($"Watcher: {watcher.Path}");
                     }
                 };
+                
+                _watchers.Add(watcher);
             }
         }
     }

--- a/src/FEntwumS.NetlistViewer/Services/ProjectMonitor.cs
+++ b/src/FEntwumS.NetlistViewer/Services/ProjectMonitor.cs
@@ -40,7 +40,7 @@ public class ProjectMonitor: IProjectMonitor
                     {
                         "Never" => AutomaticNetlistGenerationType.Never,
                         "Always" => AutomaticNetlistGenerationType.Always,
-                        "Every 5 minutes" => AutomaticNetlistGenerationType.Interval,
+                        "Interval" => AutomaticNetlistGenerationType.Interval,
                         _ => AutomaticNetlistGenerationType.Never,
                     };
 

--- a/src/FEntwumS.NetlistViewer/Services/ProjectMonitor.cs
+++ b/src/FEntwumS.NetlistViewer/Services/ProjectMonitor.cs
@@ -1,5 +1,7 @@
 ﻿using CommunityToolkit.Mvvm.Messaging;
 using DynamicData.Binding;
+using FEntwumS.NetlistViewer.Helpers;
+using FEntwumS.NetlistViewer.Types;
 using FEntwumS.NetlistViewer.Types.Messages;
 using OneWare.Essentials.Models;
 using OneWare.Essentials.Services;
@@ -10,9 +12,11 @@ namespace FEntwumS.NetlistViewer.Services;
 
 public class ProjectMonitor: IProjectMonitor
 {
+    private AutomaticNetlistGenerationType _netlistGenerationType;
+    
     private void CurrentDocument_FileSaved(IEditor editor)
     {
-        if (editor.CurrentFile is IProjectFile projectFile && projectFile.Root is UniversalFpgaProjectRoot root)
+        if (editor.CurrentFile is IProjectFile { Root: UniversalFpgaProjectRoot root } && _netlistGenerationType == AutomaticNetlistGenerationType.Always)
         {
             WeakReferenceMessenger.Default.Send(new NetlistChangedMessage(root));
         }
@@ -27,5 +31,19 @@ public class ProjectMonitor: IProjectMonitor
                 editor.FileSaved += (sender, args) => { CurrentDocument_FileSaved(editor); };
             }
         });
+
+        ServiceManager.GetService<ISettingsService>()
+            .GetSettingObservable<string>(FentwumSNetlistViewerSettingsHelper.AutomaticNetlistGenerationKey).Subscribe(
+                x =>
+                {
+                    _netlistGenerationType = x switch
+                    {
+                        "Never" => AutomaticNetlistGenerationType.Never,
+                        "Always" => AutomaticNetlistGenerationType.Always,
+                        "Every 5 minutes" => AutomaticNetlistGenerationType.Interval,
+                        _ => AutomaticNetlistGenerationType.Never,
+                    };
+
+                });
     }
 }

--- a/src/FEntwumS.NetlistViewer/Services/ProjectMonitor.cs
+++ b/src/FEntwumS.NetlistViewer/Services/ProjectMonitor.cs
@@ -1,0 +1,31 @@
+﻿using CommunityToolkit.Mvvm.Messaging;
+using DynamicData.Binding;
+using FEntwumS.NetlistViewer.Types.Messages;
+using OneWare.Essentials.Models;
+using OneWare.Essentials.Services;
+using OneWare.Essentials.ViewModels;
+using OneWare.UniversalFpgaProjectSystem.Models;
+
+namespace FEntwumS.NetlistViewer.Services;
+
+public class ProjectMonitor: IProjectMonitor
+{
+    private void CurrentDocument_FileSaved(IEditor editor)
+    {
+        if (editor.CurrentFile is IProjectFile projectFile && projectFile.Root is UniversalFpgaProjectRoot root)
+        {
+            WeakReferenceMessenger.Default.Send(new NetlistChangedMessage(root));
+        }
+    }
+    
+    public void SubscribeToSettings()
+    {
+        ServiceManager.GetService<IDockService>().WhenValueChanged(x => x.CurrentDocument).Subscribe(x =>
+        {
+            if (x is IEditor editor)
+            {
+                editor.FileSaved += (sender, args) => { CurrentDocument_FileSaved(editor); };
+            }
+        });
+    }
+}

--- a/src/FEntwumS.NetlistViewer/Services/YosysService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/YosysService.cs
@@ -107,11 +107,6 @@ public class YosysService : IYosysService
 
         _logger.Log(stderr);
 
-        if (!success)
-        {
-            _logger.Error("Please make sure that you are using yosys 0.49 or higher");
-        }
-
         return success;
     }
 

--- a/src/FEntwumS.NetlistViewer/Types/AutomaticNetlistGenerationType.cs
+++ b/src/FEntwumS.NetlistViewer/Types/AutomaticNetlistGenerationType.cs
@@ -1,0 +1,8 @@
+﻿namespace FEntwumS.NetlistViewer.Types;
+
+public enum AutomaticNetlistGenerationType
+{
+    Never = 0,
+    Always = 1,
+    Interval = 2,
+}

--- a/src/FEntwumS.NetlistViewer/Types/Messages/NetlistChangedMessage.cs
+++ b/src/FEntwumS.NetlistViewer/Types/Messages/NetlistChangedMessage.cs
@@ -1,0 +1,12 @@
+﻿using CommunityToolkit.Mvvm.Messaging.Messages;
+using OneWare.UniversalFpgaProjectSystem.Models;
+
+namespace FEntwumS.NetlistViewer.Types.Messages;
+
+public class NetlistChangedMessage : ValueChangedMessage<UniversalFpgaProjectRoot>
+{
+    public NetlistChangedMessage(UniversalFpgaProjectRoot value) : base(value)
+    {
+        
+    }
+}


### PR DESCRIPTION
This adds the option to automatically regenerate netlists (on file save or timer-based)

# TODO:
- [x] Automatic netlist regeneration
- [x] Also regenerate netlist when certain settings (eg netlist type) change

# Caveats
- Netlists that need to be regenerated due to a settings changed are *NOT* automatically regenerated. Instead they are regenerated on user action
- The automatic regeneration currently only works for supported HDLs and their file name extensions (VHDL, Verilog, SystemVerilog)