### PR TITLE
Fix VHDL code jumpback

### DIFF
--- a/src/FEntwumS.NetlistViewer/Services/CcVhdlFileIndexService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/CcVhdlFileIndexService.cs
@@ -33,6 +33,8 @@ public class CcVhdlFileIndexService : ICcVhdlFileIndexService
         long currentLine = 1, actualSrcLine = -1;
         string formattedLine = "";
 
+        bool isRelativePath = false;
+
         foreach (string line in linesToIndex)
         {
             if (Regex.IsMatch(line, @"\s+\/\*.+\*\/"))
@@ -43,6 +45,8 @@ public class CcVhdlFileIndexService : ICcVhdlFileIndexService
                 formattedLine = line.Trim();
                 // Remove block comment (first and last three characters)
                 formattedLine = formattedLine.Substring(3, formattedLine.Length - 6);
+                
+                isRelativePath = !(formattedLine.StartsWith('/') || formattedLine.IndexOf(':') == 1);
 
                 string[] formattedLineSplit = formattedLine.Split(':');
 
@@ -67,6 +71,12 @@ public class CcVhdlFileIndexService : ICcVhdlFileIndexService
                 else
                 {
                     return false;
+                }
+
+                if (isRelativePath)
+                {
+                    var filePathSplit = filePath.Split("build");
+                    formattedLine = filePathSplit[0] + formattedLine;
                 }
                 
                 fileIndexToSource[currentLine] = formattedLine;

--- a/src/FEntwumS.NetlistViewer/Services/CcVhdlFileIndexService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/CcVhdlFileIndexService.cs
@@ -46,8 +46,9 @@ public class CcVhdlFileIndexService : ICcVhdlFileIndexService
 
                 string[] formattedLineSplit = formattedLine.Split(':');
 
-                if (PlatformHelper.Platform is PlatformId.WinArm64 or PlatformId.WinX64)
+                if (PlatformHelper.Platform is PlatformId.WinArm64 or PlatformId.WinX64 && formattedLineSplit[0].Length == 1)
                 {
+                    // If necessary, re-add the drive letter for absolute paths on windows
                     formattedLine = $"{formattedLineSplit[0]}:{formattedLineSplit[1]}";
                     actualSrcLine = long.Parse(formattedLineSplit[2]);
                 } else if (PlatformHelper.Platform is not PlatformId.Wasm or PlatformId.Unknown)

--- a/src/FEntwumS.NetlistViewer/Services/FrontendService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/FrontendService.cs
@@ -518,7 +518,7 @@ public class FrontendService : IFrontendService
         ApplicationProcess indexProc = _applicationStateService.AddState("Indexing", AppState.Loading);
 
         // create code index for cross-compiled VHDL
-        string ccFile = Path.Combine(json.Root.FullPath, "build", "netlist", "design.v");
+        string ccFile = Path.Combine(json.Root.FullPath, "build", "netlist", $"{top}.v");
 
         if (File.Exists(ccFile))
         {


### PR DESCRIPTION
Currently, clicking on a cell to view the corresponding source line is broken for VHDL designs. The cause is twofold:
- The naming scheme of the cross-compiled Verilog file was changed, but this change was not propagated to the indexing of said file
- The previously used implementation of the GhdlService used for netlist generation used absolute paths to point to the source files, whereas the new implementation from the Ghdl extension uses relative paths. This messed up the handling of drive letters on windows, as well as returning the wrong location (now relative to the plugin directory).