### PR TITLE
Migration/ows1.0 project explorer

### DIFF
--- a/src/FEntwumS.NetlistViewer/Controls/NetlistControl.cs
+++ b/src/FEntwumS.NetlistViewer/Controls/NetlistControl.cs
@@ -1158,7 +1158,7 @@ public class NetlistControl : TemplatedControl, ICustomHitTest
 
         var ds = ServiceManager.GetService<IMainDockService>();
 
-        var document = await ds.OpenFileAsync(new ExternalFile(filename));
+        var document = await ds.OpenFileAsync(filename);
 
         (document as IEditor)?.JumpToLine((int)line);
     }

--- a/src/FEntwumS.NetlistViewer/FEntwumS.NetlistViewer.csproj
+++ b/src/FEntwumS.NetlistViewer/FEntwumS.NetlistViewer.csproj
@@ -25,14 +25,14 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="OneWare.Essentials" Version="0.99.6" Private="false" ExcludeAssets="runtime;Native">
+      <PackageReference Include="OneWare.Essentials" Version="1.0.0" Private="false" ExcludeAssets="runtime;Native">
               <PrivateAssets>all</PrivateAssets>
               <IncludeAssets>compile; build; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="OneWare.GhdlExtension" Version="0.99.5" Private="true">
+      <PackageReference Include="OneWare.GhdlExtension" Version="1.0.0" Private="true">
           <ExcludeAssets>runtime; Native</ExcludeAssets>
       </PackageReference>
-      <PackageReference Include="OneWare.UniversalFpgaProjectSystem" Version="0.99.6" Private="false" ExcludeAssets="runtime;Native">
+      <PackageReference Include="OneWare.UniversalFpgaProjectSystem" Version="1.0.0" Private="false" ExcludeAssets="runtime;Native">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>compile; build; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/src/FEntwumS.NetlistViewer/FEntwumS.NetlistViewer.csproj
+++ b/src/FEntwumS.NetlistViewer/FEntwumS.NetlistViewer.csproj
@@ -25,14 +25,14 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="OneWare.Essentials" Version="0.99.5" Private="false" ExcludeAssets="runtime;Native">
+      <PackageReference Include="OneWare.Essentials" Version="0.99.6" Private="false" ExcludeAssets="runtime;Native">
               <PrivateAssets>all</PrivateAssets>
               <IncludeAssets>compile; build; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="OneWare.GhdlExtension" Version="0.99.5" Private="true">
           <ExcludeAssets>runtime; Native</ExcludeAssets>
       </PackageReference>
-      <PackageReference Include="OneWare.UniversalFpgaProjectSystem" Version="0.99.5" Private="false" ExcludeAssets="runtime;Native">
+      <PackageReference Include="OneWare.UniversalFpgaProjectSystem" Version="0.99.6" Private="false" ExcludeAssets="runtime;Native">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>compile; build; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
+++ b/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
@@ -683,7 +683,7 @@ public class FEntwumSNetlistReaderFrontendModule : OneWareModuleBase
 			}
 			catch (ReflectionTypeLoadException ex)
 			{
-				ServiceManager.GetService<ILogger>().Error("An issue occured during settings subscription\n\nPlease file a bug report!", ex);
+				ServiceManager.GetService<ILogger>().Error("[FEntwumS.NetlistViewer]: An issue occured during settings subscription\n\nPlease file a bug report!", ex);
 			}
 		}
 

--- a/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
+++ b/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
@@ -444,7 +444,7 @@ public class FEntwumSNetlistReaderFrontendModule : OneWareModuleBase
 			
 			if (selected is [IProjectFile { Extension: ".json" } jsonFile])
 			{
-				menuItems.Add(new MenuItemViewModel("NetlistViewer")
+				menuItems.Add(new MenuItemModel("NetlistViewer")
 				{
 					Header = $"View netlist {jsonFile.Header}",
 					Command = new AsyncRelayCommand(() => ServiceManager.GetService<FrontendService>().ShowViewerAsync(jsonFile))
@@ -452,7 +452,7 @@ public class FEntwumSNetlistReaderFrontendModule : OneWareModuleBase
 			}
 			else if (selected is [IProjectFile { Extension: ".vhd" } vhdlFile])
 			{
-				menuItems.Add(new MenuItemViewModel("NetlistViewer_CreateNetlist")
+				menuItems.Add(new MenuItemModel("NetlistViewer_CreateNetlist")
 				{
 					Header = $"View netlist for {vhdlFile.Header}",
 					Command = new AsyncRelayCommand(() => ServiceManager.GetService<FrontendService>().CreateVhdlNetlistAsync(vhdlFile))
@@ -460,7 +460,7 @@ public class FEntwumSNetlistReaderFrontendModule : OneWareModuleBase
 			}
 			else if (selected is [IProjectFile { Extension: ".v" } verilogFile])
 			{
-				menuItems.Add(new MenuItemViewModel("NetlistViewer_CreateVerilogNetlist")
+				menuItems.Add(new MenuItemModel("NetlistViewer_CreateVerilogNetlist")
 				{
 					Header = $"View netlist for {verilogFile.Header}",
 					Command = new AsyncRelayCommand(() => ServiceManager.GetService<FrontendService>().CreateVerilogNetlistAsync(verilogFile))
@@ -468,7 +468,7 @@ public class FEntwumSNetlistReaderFrontendModule : OneWareModuleBase
 			}
 			else if (selected is [IProjectFile { Extension: ".sv" } systemVerilogFile])
 			{
-				menuItems.Add(new MenuItemViewModel("NetlistViewer_CreateSystemVerilogNetlist")
+				menuItems.Add(new MenuItemModel("NetlistViewer_CreateSystemVerilogNetlist")
 				{
 					Header = $"View netlist for {systemVerilogFile.Header}",
 					Command = new AsyncRelayCommand(() =>
@@ -488,7 +488,7 @@ public class FEntwumSNetlistReaderFrontendModule : OneWareModuleBase
 
 			if (selected is [IProjectFile { Extension: ".vhd" } vhdlFile])
 			{
-				menuItems.Add(new MenuItemViewModel("NetlistViewer_VHDLHierarchy")
+				menuItems.Add(new MenuItemModel("NetlistViewer_VHDLHierarchy")
 				{
 					Header = $"View design hierarchy for {vhdlFile.Header}",
 					Command = new AsyncRelayCommand(() => ServiceManager.GetService<FrontendService>().CreateVhdlHierarchyAsync(vhdlFile))
@@ -496,7 +496,7 @@ public class FEntwumSNetlistReaderFrontendModule : OneWareModuleBase
 			}
 			else if (selected is [IProjectFile { Extension: ".v" } verilogFile])
 			{
-				menuItems.Add(new MenuItemViewModel("NetlistViewer_VerilogHierarchy")
+				menuItems.Add(new MenuItemModel("NetlistViewer_VerilogHierarchy")
 				{
 					Header = $"View design hierarchy for {verilogFile.Header}",
 					Command = new AsyncRelayCommand(() => ServiceManager.GetService<FrontendService>().CreateVerilogHierarchyAsync(verilogFile))
@@ -504,7 +504,7 @@ public class FEntwumSNetlistReaderFrontendModule : OneWareModuleBase
 			}
 			else if (selected is [IProjectFile { Extension: ".sv" } systemVerilogFile])
 			{
-				menuItems.Add(new MenuItemViewModel("NetlistViewer_SystemVerilogHierarchy")
+				menuItems.Add(new MenuItemModel("NetlistViewer_SystemVerilogHierarchy")
 				{
 					Header = $"View design hierarchy for {systemVerilogFile.Header}",
 					Command = new AsyncRelayCommand(() =>

--- a/src/FEntwumS.NetlistViewer/Helpers/FentwumSNetlistViewerSettingsHelper.cs
+++ b/src/FEntwumS.NetlistViewer/Helpers/FentwumSNetlistViewerSettingsHelper.cs
@@ -59,8 +59,8 @@ public class FentwumSNetlistViewerSettingsHelper
 
 	#region Project settings keys
 
-	public static readonly string ProjectFpgaManufacturerKey = "FEntwumS_FPGA_Manufacturer";
-	public static readonly string ProjectFpgaDeviceFamilyKey = "FEntwumS_FPGA_DeviceFamily";
+	public static readonly string ProjectFpgaManufacturerKey = "FEntwumS/FPGA/manufacturer";
+	public static readonly string ProjectFpgaDeviceFamilyKey = "FEntwumS/FPGA/deviceFamily";
 
 	#endregion
 

--- a/src/FEntwumS.NetlistViewer/Helpers/SettingsUpgrader.cs
+++ b/src/FEntwumS.NetlistViewer/Helpers/SettingsUpgrader.cs
@@ -1,7 +1,5 @@
-﻿using Avalonia.Animation;
-using FEntwumS.NetlistViewer.Services;
+﻿using FEntwumS.NetlistViewer.Services;
 using OneWare.Essentials.Services;
-using OneWare.UniversalFpgaProjectSystem.Models;
 
 namespace FEntwumS.NetlistViewer.Helpers;
 
@@ -13,7 +11,6 @@ public class SettingsUpgrader
 		string currentSettingsVersion =
 			storageService.GetKeyValuePairValue(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey) ?? "0";
 
-		//return true;
 		return currentSettingsVersion != FentwumSNetlistViewerSettingsHelper.ExpectedSettingsVersion;
 	}
 
@@ -52,21 +49,6 @@ public class SettingsUpgrader
 			settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.EnableHierarchyViewKey, true);
 			settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.AlwaysRegenerateNetlistsKey, false);
 		}
-		
-		projectExplorerService.Projects.CollectionChanged += (sender, args) =>
-		{
-			foreach (var p in args.NewItems)
-			{
-				if (p is UniversalFpgaProjectRoot root)
-				{
-					root.Properties.SetString(FentwumSNetlistViewerSettingsHelper.ProjectFpgaManufacturerKey,
-						root.Properties.GetString("FEntwumS_FPGA_Manufacturer"));
-					
-					root.Properties.SetString(FentwumSNetlistViewerSettingsHelper.ProjectFpgaDeviceFamilyKey,
-						root.Properties.GetString("FEntwumS_FPGA_DeviceFamily"));
-				}
-			}
-		};
 
 		storageService.SetKeyValuePairValue(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey,
 			FentwumSNetlistViewerSettingsHelper.ExpectedSettingsVersion);

--- a/src/FEntwumS.NetlistViewer/Helpers/SettingsUpgrader.cs
+++ b/src/FEntwumS.NetlistViewer/Helpers/SettingsUpgrader.cs
@@ -1,50 +1,75 @@
 ﻿using Avalonia.Animation;
 using FEntwumS.NetlistViewer.Services;
 using OneWare.Essentials.Services;
+using OneWare.UniversalFpgaProjectSystem.Models;
 
 namespace FEntwumS.NetlistViewer.Helpers;
 
 public class SettingsUpgrader
 {
-    public static bool NeedsUpgrade()
-    {
-        IStorageService storageService = ServiceManager.GetService<IStorageService>();
-        string currentSettingsVersion = storageService.GetKeyValuePairValue(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey) ?? "0";
-        
-        return currentSettingsVersion != FentwumSNetlistViewerSettingsHelper.ExpectedSettingsVersion;
-    }
-    
-    public static async Task UpgradeSettingsIfNecessaryAsync()
-    {
-        ISettingsService settingsService = ServiceManager.GetService<ISettingsService>();
-        IStorageService storageService = ServiceManager.GetService<IStorageService>();
-        IPaths paths = ServiceManager.GetService<IPaths>();
-        int currentSettingsVersion = Convert.ToInt32(storageService.GetKeyValuePairValue(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey) ?? "0");
-        
+	public static bool NeedsUpgrade()
+	{
+		IStorageService storageService = ServiceManager.GetService<IStorageService>();
+		string currentSettingsVersion =
+			storageService.GetKeyValuePairValue(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey) ?? "0";
 
-        if (currentSettingsVersion <= 0)
-        {
-            settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.EnableHierarchyViewKey, true);
-        }
+		//return true;
+		return currentSettingsVersion != FentwumSNetlistViewerSettingsHelper.ExpectedSettingsVersion;
+	}
 
-        if (currentSettingsVersion <= 1)
-        {
-            if (settingsService.GetSettingValue<string>(FentwumSNetlistViewerSettingsHelper
-                    .AutomaticNetlistGenerationKey) == "Every 5 minutes")
-            {
-                settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.AutomaticNetlistGenerationKey, "Interval");
-            }
-        }
+	public static async Task UpgradeSettingsIfNecessaryAsync()
+	{
+		ISettingsService settingsService = ServiceManager.GetService<ISettingsService>();
+		IStorageService storageService = ServiceManager.GetService<IStorageService>();
+		IPaths paths = ServiceManager.GetService<IPaths>();
+		IProjectExplorerService projectExplorerService = ServiceManager.GetService<IProjectExplorerService>();
+		int currentSettingsVersion =
+			Convert.ToInt32(
+				storageService.GetKeyValuePairValue(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey) ??
+				"0");
 
-        if (currentSettingsVersion <= 2)
-        {
-	        settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.UseHierarchicalBackendKey, true);
-	        settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.PerformanceTargetKey, "Intelligent Ahead Of Time");
-	        settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.EnableHierarchyViewKey, true);
-	        settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.AlwaysRegenerateNetlistsKey, false);
-        }
-        
-        storageService.SetKeyValuePairValue(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey, FentwumSNetlistViewerSettingsHelper.ExpectedSettingsVersion);
-        await storageService.SaveAsync();
-    }
+
+		if (currentSettingsVersion <= 0)
+		{
+			settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.EnableHierarchyViewKey, true);
+		}
+
+		if (currentSettingsVersion <= 1)
+		{
+			if (settingsService.GetSettingValue<string>(FentwumSNetlistViewerSettingsHelper
+				    .AutomaticNetlistGenerationKey) == "Every 5 minutes")
+			{
+				settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.AutomaticNetlistGenerationKey,
+					"Interval");
+			}
+		}
+
+		if (currentSettingsVersion <= 2)
+		{
+			settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.UseHierarchicalBackendKey, true);
+			settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.PerformanceTargetKey,
+				"Intelligent Ahead Of Time");
+			settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.EnableHierarchyViewKey, true);
+			settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.AlwaysRegenerateNetlistsKey, false);
+		}
+		
+		projectExplorerService.Projects.CollectionChanged += (sender, args) =>
+		{
+			foreach (var p in args.NewItems)
+			{
+				if (p is UniversalFpgaProjectRoot root)
+				{
+					root.Properties.SetString(FentwumSNetlistViewerSettingsHelper.ProjectFpgaManufacturerKey,
+						root.Properties.GetString("FEntwumS_FPGA_Manufacturer"));
+					
+					root.Properties.SetString(FentwumSNetlistViewerSettingsHelper.ProjectFpgaDeviceFamilyKey,
+						root.Properties.GetString("FEntwumS_FPGA_DeviceFamily"));
+				}
+			}
+		};
+
+		storageService.SetKeyValuePairValue(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey,
+			FentwumSNetlistViewerSettingsHelper.ExpectedSettingsVersion);
+		await storageService.SaveAsync();
+	}
 }

--- a/src/FEntwumS.NetlistViewer/Services/FpgaBbService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/FpgaBbService.cs
@@ -61,20 +61,20 @@ public class FpgaBbService : IFpgaBbService
 		}
 		else
 		{
-			manufacturer = root.GetProjectProperty(FentwumSNetlistViewerSettingsHelper.ProjectFpgaManufacturerKey);
+			manufacturer = root.Properties.GetString(FentwumSNetlistViewerSettingsHelper.ProjectFpgaManufacturerKey);
 
 			if (manufacturer is null)
 			{
 				manufacturer = _currentManufacturer;
-				root.SetProjectProperty(FentwumSNetlistViewerSettingsHelper.ProjectFpgaManufacturerKey, manufacturer);
+				root.Properties.SetString(FentwumSNetlistViewerSettingsHelper.ProjectFpgaManufacturerKey, manufacturer);
 			}
 
-			deviceFamily = root.GetProjectProperty(FentwumSNetlistViewerSettingsHelper.ProjectFpgaDeviceFamilyKey);
+			deviceFamily = root.Properties.GetString(FentwumSNetlistViewerSettingsHelper.ProjectFpgaDeviceFamilyKey);
 
 			if (deviceFamily is null)
 			{
 				deviceFamily = _currentDeviceFamily;
-				root.SetProjectProperty(FentwumSNetlistViewerSettingsHelper.ProjectFpgaDeviceFamilyKey, deviceFamily);
+				root.Properties.SetString(FentwumSNetlistViewerSettingsHelper.ProjectFpgaDeviceFamilyKey, deviceFamily);
 			}
 		}
 

--- a/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
+++ b/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
@@ -54,7 +54,7 @@ public class NetlistGenerator : INetlistGenerator
 			Directory.CreateDirectory(outputDir);
 		}
 
-		return await ghdlService.SynthAsync(vhdlProject, "verilog", outputDir);
+		return await ghdlService.SynthAsync(vhdlProject.FullPath, "verilog", outputDir);
 	}
 
 	public async Task<bool> GenerateVerilogNetlistAsync(IProjectFile verilogProject)

--- a/src/FEntwumS.NetlistViewer/Services/YosysService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/YosysService.cs
@@ -63,17 +63,17 @@ public class YosysService : IYosysService
 		else
 		{
 			if (file.Root is not UniversalFpgaProjectRoot root) return false;
-			IEnumerable<string> verilogFiles = root.Files
-				.Where(x => !root.CompileExcluded.Contains(x)) // Exclude excluded files
-				.Where(x => x.Extension is ".v") // Include only Verilog files
-				.Where(x => !root.TestBenches.Contains(x)) // Exclude testbenches
-				.Select(x => x.FullPath);
+			IEnumerable<string> verilogFiles = root.GetFiles()
+				.Where(x => !root.IsCompileExcluded(x)) // Exclude excluded files
+				.Where(x => Path.GetExtension(x) is ".v") // Include only Verilog files
+				.Where(x => !root.IsTestBench(x)) // Exclude testbenches
+				.Select(x => x);
 
-			IEnumerable<string> systemVerilogFiles = root.Files
-				.Where(x => !root.CompileExcluded.Contains(x)) // Exclude excluded files
-				.Where(x => x.Extension is ".sv") // Include only SystemVerilog files
-				.Where(x => !root.TestBenches.Contains(x)) // Exclude testbenches
-				.Select(x => x.FullPath);
+			IEnumerable<string> systemVerilogFiles = root.GetFiles()
+				.Where(x => !root.IsCompileExcluded(x)) // Exclude excluded files
+				.Where(x => Path.GetExtension(x) is ".sv") // Include only SystemVerilog files
+				.Where(x => !root.IsTestBench(x)) // Exclude testbenches
+				.Select(x => x);
 
 			verilogFileList.AddRange(verilogFiles);
 			systemVerilogFileList.AddRange(systemVerilogFiles);
@@ -128,11 +128,11 @@ public class YosysService : IYosysService
 		string top = Path.GetFileNameWithoutExtension(file.FullPath);
 
 		if (file.Root is not UniversalFpgaProjectRoot root) return false;
-		IEnumerable<string> files = root.Files
-			.Where(x => !root.CompileExcluded.Contains(x)) // Exclude excluded files
-			.Where(x => x.Extension is ".sv") // Include only SystemVerilog files
-			.Where(x => !root.TestBenches.Contains(x)) // Exclude testbenches
-			.Select(x => x.FullPath);
+		IEnumerable<string> files = root.GetFiles()
+			.Where(x => !root.IsCompileExcluded(x)) // Exclude excluded files
+			.Where(x => Path.GetExtension(x) is ".sv") // Include only SystemVerilog files
+			.Where(x => !root.IsTestBench(x)) // Exclude testbenches
+			.Select(x => x);
 		// TODO
 		// get verilog files
 

--- a/src/FEntwumS.NetlistViewer/Services/YosysService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/YosysService.cs
@@ -66,12 +66,12 @@ public class YosysService : IYosysService
 			IEnumerable<string> verilogFiles = root.GetFiles("*.v")
 				.Where(x => !root.IsCompileExcluded(x)) // Exclude excluded files
 				.Where(x => !root.IsTestBench(x)) // Exclude testbenches
-				.Select(x => x);
-
+				.Select(x => Path.Combine(root.TopFolder.FullPath, x));
+			
 			IEnumerable<string> systemVerilogFiles = root.GetFiles("*.sv")
 				.Where(x => !root.IsCompileExcluded(x)) // Exclude excluded files
 				.Where(x => !root.IsTestBench(x)) // Exclude testbenches
-				.Select(x => x);
+				.Select(x => Path.Combine(root.TopFolder.FullPath, x));
 
 			verilogFileList.AddRange(verilogFiles);
 			systemVerilogFileList.AddRange(systemVerilogFiles);
@@ -88,7 +88,7 @@ public class YosysService : IYosysService
 			+ "memory -nomap; " // Converts memories into simple blocks instead of basic cells
 			+ "select *; " // Remove unnecessary library elements from the netlist
 			+ $"write_json -compat-int {top}-hier.json; " // Write hierarchical JSON netlist to disk
-			+ "scratchpad -set flatten.separator \";\"; "
+			+ "scratchpad -set flatten.separator \';\'; "
 			+ "flatten -scopename; " // Flatten the netlist
 			+ "select *; "
 			+ "clean; "

--- a/src/FEntwumS.NetlistViewer/Services/YosysService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/YosysService.cs
@@ -63,15 +63,13 @@ public class YosysService : IYosysService
 		else
 		{
 			if (file.Root is not UniversalFpgaProjectRoot root) return false;
-			IEnumerable<string> verilogFiles = root.GetFiles()
+			IEnumerable<string> verilogFiles = root.GetFiles("*.v")
 				.Where(x => !root.IsCompileExcluded(x)) // Exclude excluded files
-				.Where(x => Path.GetExtension(x) is ".v") // Include only Verilog files
 				.Where(x => !root.IsTestBench(x)) // Exclude testbenches
 				.Select(x => x);
 
-			IEnumerable<string> systemVerilogFiles = root.GetFiles()
+			IEnumerable<string> systemVerilogFiles = root.GetFiles("*.sv")
 				.Where(x => !root.IsCompileExcluded(x)) // Exclude excluded files
-				.Where(x => Path.GetExtension(x) is ".sv") // Include only SystemVerilog files
 				.Where(x => !root.IsTestBench(x)) // Exclude testbenches
 				.Select(x => x);
 
@@ -128,9 +126,8 @@ public class YosysService : IYosysService
 		string top = Path.GetFileNameWithoutExtension(file.FullPath);
 
 		if (file.Root is not UniversalFpgaProjectRoot root) return false;
-		IEnumerable<string> files = root.GetFiles()
+		IEnumerable<string> files = root.GetFiles("*.sv")
 			.Where(x => !root.IsCompileExcluded(x)) // Exclude excluded files
-			.Where(x => Path.GetExtension(x) is ".sv") // Include only SystemVerilog files
 			.Where(x => !root.IsTestBench(x)) // Exclude testbenches
 			.Select(x => x);
 		// TODO

--- a/tests/FEntwumS.NetlistViewer.UnitTests/FEntwumS.NetlistViewer.UnitTests.csproj
+++ b/tests/FEntwumS.NetlistViewer.UnitTests/FEntwumS.NetlistViewer.UnitTests.csproj
@@ -15,9 +15,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="OneWare.Essentials" Version="0.99.6" />
-      <PackageReference Include="OneWare.GhdlExtension" Version="0.99.5" />
-      <PackageReference Include="OneWare.UniversalFpgaProjectSystem" Version="0.99.6" />
+      <PackageReference Include="OneWare.Essentials" Version="1.0.0" />
+      <PackageReference Include="OneWare.GhdlExtension" Version="1.0.0" />
+      <PackageReference Include="OneWare.UniversalFpgaProjectSystem" Version="1.0.0" />
     </ItemGroup>
 
 </Project>

--- a/tests/FEntwumS.NetlistViewer.UnitTests/FEntwumS.NetlistViewer.UnitTests.csproj
+++ b/tests/FEntwumS.NetlistViewer.UnitTests/FEntwumS.NetlistViewer.UnitTests.csproj
@@ -15,9 +15,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="OneWare.Essentials" Version="0.99.5" />
+      <PackageReference Include="OneWare.Essentials" Version="0.99.6" />
       <PackageReference Include="OneWare.GhdlExtension" Version="0.99.5" />
-      <PackageReference Include="OneWare.UniversalFpgaProjectSystem" Version="0.99.5" />
+      <PackageReference Include="OneWare.UniversalFpgaProjectSystem" Version="0.99.6" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR implements the necessary migrations to use the interfaces of the reworked `IProjectExplorerService`. All regressions caused by the aforementioned changes have been fixed as well. The functionality of the extension has been tested, starting from the dependency installation process, covering netlist generation for VHDL and Verilog projects of varying complexity and size, checking the functionality of the jump to code functionality of the netlist view (also for both VHDL and Verilog), and finally the hierarchy viewer, where both the textual and graphical representations were tested