### PR TITLE
Fix/41 library redefinition

### DIFF
--- a/src/FEntwumS.NetlistViewer/Services/FpgaBbService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/FpgaBbService.cs
@@ -81,32 +81,32 @@ public class FpgaBbService : IFpgaBbService
 		switch (manufacturer)
 		{
 			case "achronix":
-				return "read_verilog -sv -lib -overwrite +/achronix/speedster22i/cells_sim.v;";
+				return "read_verilog -sv -lib -nooverwrite +/achronix/speedster22i/cells_sim.v;";
 
 			case "anlogic":
-				return "read_verilog -lib -overwrite +/anlogic/cells_sim.v +/anlogic/eagle_bb.v;";
+				return "read_verilog -lib -nooverwrite +/anlogic/cells_sim.v +/anlogic/eagle_bb.v;";
 
 			case "coolrunner2":
-				return "read_verilog -lib -overwrite +/coolrunner2/cells_sim.v;";
+				return "read_verilog -lib -nooverwrite +/coolrunner2/cells_sim.v;";
 
 			case "ecp5":
-				return "read_verilog -lib -specify -overwrite +/ecp5/cells_sim.v +/ecp5/cells_bb.v;";
+				return "read_verilog -lib -specify -nooverwrite +/ecp5/cells_sim.v +/ecp5/cells_bb.v;";
 
 			case "efinix":
-				return "read_verilog -lib -overwrite +/efinix/cells_sim.v;";
+				return "read_verilog -lib -nooverwrite +/efinix/cells_sim.v;";
 
 			case "fabulous":
-				return "read_verilog -lib -overwrite +/fabulous/prims.v;";
+				return "read_verilog -lib -nooverwrite +/fabulous/prims.v;";
 
 			case "gatemate":
-				return "read_verilog -lib -specify -overwrite +/gatemate/cells_sim.v +/gatemate/cells_bb.v;";
+				return "read_verilog -lib -specify -nooverwrite +/gatemate/cells_sim.v +/gatemate/cells_bb.v;";
 
 			case "gowin":
 				if (deviceFamily is "gw1n" or "gw2a" or "gw5a")
 				{
 					return
-						"read_verilog -specify -lib -overwrite +/gowin/cells_sim.v; " +
-						$"read_verilog -specify -lib -overwrite +/gowin/cells_xtra_{deviceFamily}.v;";
+						"read_verilog -specify -lib -nooverwrite +/gowin/cells_sim.v; " +
+						$"read_verilog -specify -lib -nooverwrite +/gowin/cells_xtra_{deviceFamily}.v;";
 				}
 
 				_logger.Error(
@@ -115,29 +115,29 @@ public class FpgaBbService : IFpgaBbService
 				break;
 
 			case "greenpak4":
-				return "read_verilog -lib -overwrite +/greenpak4/cells_sim.v;";
+				return "read_verilog -lib -nooverwrite +/greenpak4/cells_sim.v;";
 
 			case "ice40":
-				return "read_verilog -D ICE40_HX -lib -specify -overwrite +/ice40/cells_sim.v;";
+				return "read_verilog -D ICE40_HX -lib -specify -nooverwrite +/ice40/cells_sim.v;";
 
 			case "intel":
 				return
-					"read_verilog -sv -lib -overwrite +/intel/max10/cells_sim.v; " +
-					"read_verilog -sv -lib -overwrite +/intel/common/m9k_bb.v; " +
-					"read_verilog -sv -lib -overwrite +/intel/common/altpll_bb.v;";
+					"read_verilog -sv -lib -nooverwrite +/intel/max10/cells_sim.v; " +
+					"read_verilog -sv -lib -nooverwrite +/intel/common/m9k_bb.v; " +
+					"read_verilog -sv -lib -nooverwrite +/intel/common/altpll_bb.v;";
 
 			case "intel_alm":
 				if (deviceFamily is "cyclonev")
 				{
 					return
-						$"read_verilog -specify -lib -D {deviceFamily} -overwrite +/intel_alm/common/alm_sim.v; " +
-						$"read_verilog -specify -lib -D {deviceFamily} -overwrite +/intel_alm/common/dff_sim.v; " +
-						$"read_verilog -specify -lib -D {deviceFamily} -overwrite +/intel_alm/common/dsp_sim.v; " +
-						$"read_verilog -specify -lib -D {deviceFamily} -overwrite +/intel_alm/common/mem_sim.v; " +
-						$"read_verilog -specify -lib -D {deviceFamily} -overwrite +/intel_alm/common/misc_sim.v; " +
-						$"read_verilog -specify -lib -D {deviceFamily} -overwrite -icells +/intel_alm/common/abc9_model.v; " +
-						"read_verilog -lib -overwrite +/intel/common/altpll_bb.v; " +
-						"read_verilog -lib -overwrite +/intel_alm/common/megafunction_bb.v;";
+						$"read_verilog -specify -lib -D {deviceFamily} -nooverwrite +/intel_alm/common/alm_sim.v; " +
+						$"read_verilog -specify -lib -D {deviceFamily} -nooverwrite +/intel_alm/common/dff_sim.v; " +
+						$"read_verilog -specify -lib -D {deviceFamily} -nooverwrite +/intel_alm/common/dsp_sim.v; " +
+						$"read_verilog -specify -lib -D {deviceFamily} -nooverwrite +/intel_alm/common/mem_sim.v; " +
+						$"read_verilog -specify -lib -D {deviceFamily} -nooverwrite +/intel_alm/common/misc_sim.v; " +
+						$"read_verilog -specify -lib -D {deviceFamily} -nooverwrite -icells +/intel_alm/common/abc9_model.v; " +
+						"read_verilog -lib -nooverwrite +/intel/common/altpll_bb.v; " +
+						"read_verilog -lib -nooverwrite +/intel_alm/common/megafunction_bb.v;";
 				}
 
 				_logger.Error(
@@ -146,23 +146,23 @@ public class FpgaBbService : IFpgaBbService
 				break;
 
 			case "lattice":
-				return "read_verilog -lib -specify -overwrite +/lattice/cells_sim.v +/lattice/cells_bb.v;";
+				return "read_verilog -lib -specify -nooverwrite +/lattice/cells_sim.v +/lattice/cells_bb.v;";
 
 			case "microchip":
-				return "read_verilog -lib -specify -overwrite +/microchip/cells_sim.v;";
+				return "read_verilog -lib -specify -nooverwrite +/microchip/cells_sim.v;";
 
 			case "nanoxplore":
 				return
-					"read_verilog -lib -specify -overwrite +/nanoxplore/cells_sim.v +/nanoxplore/cells_sim.v +/nanoxplore/cells_bb.v +/nanoxplore/cells_bb.v;";
+					"read_verilog -lib -specify -nooverwrite +/nanoxplore/cells_sim.v +/nanoxplore/cells_sim.v +/nanoxplore/cells_bb.v +/nanoxplore/cells_bb.v;";
 
 			case "nexus":
-				return "read_verilog -lib -specify -overwrite +/nexus/cells_sim.v +/nexus/cells_xtra.v;";
+				return "read_verilog -lib -specify -nooverwrite +/nexus/cells_sim.v +/nexus/cells_xtra.v;";
 
 			case "quicklogic":
 				if (deviceFamily is "pp3" or "qlf_k6n10f")
 				{
 					return
-						$"read_verilog -lib -specify -overwrite +/quicklogic/common/cells_sim.v +/quicklogic/{deviceFamily}/cells_sim.v;";
+						$"read_verilog -lib -specify -nooverwrite +/quicklogic/common/cells_sim.v +/quicklogic/{deviceFamily}/cells_sim.v;";
 				}
 
 				_logger.Error(
@@ -170,11 +170,11 @@ public class FpgaBbService : IFpgaBbService
 				break;
 
 			case "sf2":
-				return "read_verilog -lib -overwrite +/sf2/cells_sim.v;";
+				return "read_verilog -lib -nooverwrite +/sf2/cells_sim.v;";
 
 			case "xilinx":
-				return "read_verilog -lib -overwrite -specify +/xilinx/cells_sim.v; " +
-				       "read_verilog -lib -overwrite +/xilinx/cells_xtra.v;";
+				return "read_verilog -lib -nooverwrite -specify +/xilinx/cells_sim.v; " +
+				       "read_verilog -lib -nooverwrite +/xilinx/cells_xtra.v;";
 
 			default:
 				_logger.Error("Unknown device manufacturer");

--- a/src/FEntwumS.NetlistViewer/Services/FpgaBbService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/FpgaBbService.cs
@@ -81,32 +81,32 @@ public class FpgaBbService : IFpgaBbService
 		switch (manufacturer)
 		{
 			case "achronix":
-				return "read_verilog -sv -lib +/achronix/speedster22i/cells_sim.v;";
+				return "read_verilog -sv -lib -overwrite +/achronix/speedster22i/cells_sim.v;";
 
 			case "anlogic":
-				return "read_verilog -lib +/anlogic/cells_sim.v +/anlogic/eagle_bb.v;";
+				return "read_verilog -lib -overwrite +/anlogic/cells_sim.v +/anlogic/eagle_bb.v;";
 
 			case "coolrunner2":
-				return "read_verilog -lib +/coolrunner2/cells_sim.v;";
+				return "read_verilog -lib -overwrite +/coolrunner2/cells_sim.v;";
 
 			case "ecp5":
-				return "read_verilog -lib -specify +/ecp5/cells_sim.v +/ecp5/cells_bb.v;";
+				return "read_verilog -lib -specify -overwrite +/ecp5/cells_sim.v +/ecp5/cells_bb.v;";
 
 			case "efinix":
-				return "read_verilog -lib +/efinix/cells_sim.v;";
+				return "read_verilog -lib -overwrite +/efinix/cells_sim.v;";
 
 			case "fabulous":
-				return "read_verilog  -lib +/fabulous/prims.v;";
+				return "read_verilog -lib -overwrite +/fabulous/prims.v;";
 
 			case "gatemate":
-				return "read_verilog -lib -specify +/gatemate/cells_sim.v +/gatemate/cells_bb.v;";
+				return "read_verilog -lib -specify -overwrite +/gatemate/cells_sim.v +/gatemate/cells_bb.v;";
 
 			case "gowin":
 				if (deviceFamily is "gw1n" or "gw2a" or "gw5a")
 				{
 					return
-						"read_verilog -specify -lib +/gowin/cells_sim.v; " +
-						$"read_verilog -specify -lib +/gowin/cells_xtra_{deviceFamily}.v;";
+						"read_verilog -specify -lib -overwrite +/gowin/cells_sim.v; " +
+						$"read_verilog -specify -lib -overwrite +/gowin/cells_xtra_{deviceFamily}.v;";
 				}
 
 				_logger.Error(
@@ -115,29 +115,29 @@ public class FpgaBbService : IFpgaBbService
 				break;
 
 			case "greenpak4":
-				return "read_verilog -lib +/greenpak4/cells_sim.v;";
+				return "read_verilog -lib -overwrite +/greenpak4/cells_sim.v;";
 
 			case "ice40":
-				return "read_verilog -D ICE40_HX -lib -specify +/ice40/cells_sim.v;";
+				return "read_verilog -D ICE40_HX -lib -specify -overwrite +/ice40/cells_sim.v;";
 
 			case "intel":
 				return
-					"read_verilog -sv -lib +/intel/max10/cells_sim.v; " +
-					"read_verilog -sv -lib +/intel/common/m9k_bb.v; " +
-					"read_verilog -sv -lib +/intel/common/altpll_bb.v;";
+					"read_verilog -sv -lib -overwrite +/intel/max10/cells_sim.v; " +
+					"read_verilog -sv -lib -overwrite +/intel/common/m9k_bb.v; " +
+					"read_verilog -sv -lib -overwrite +/intel/common/altpll_bb.v;";
 
 			case "intel_alm":
 				if (deviceFamily is "cyclonev")
 				{
 					return
-						$"read_verilog -specify -lib -D {deviceFamily} +/intel_alm/common/alm_sim.v; " +
-						$"read_verilog -specify -lib -D {deviceFamily} +/intel_alm/common/dff_sim.v; " +
-						$"read_verilog -specify -lib -D {deviceFamily} +/intel_alm/common/dsp_sim.v; " +
-						$"read_verilog -specify -lib -D {deviceFamily} +/intel_alm/common/mem_sim.v; " +
-						$"read_verilog -specify -lib -D {deviceFamily} +/intel_alm/common/misc_sim.v; " +
-						$"read_verilog -specify -lib -D {deviceFamily} -icells +/intel_alm/common/abc9_model.v; " +
-						"read_verilog -lib +/intel/common/altpll_bb.v; " +
-						"read_verilog -lib +/intel_alm/common/megafunction_bb.v;";
+						$"read_verilog -specify -lib -D {deviceFamily} -overwrite +/intel_alm/common/alm_sim.v; " +
+						$"read_verilog -specify -lib -D {deviceFamily} -overwrite +/intel_alm/common/dff_sim.v; " +
+						$"read_verilog -specify -lib -D {deviceFamily} -overwrite +/intel_alm/common/dsp_sim.v; " +
+						$"read_verilog -specify -lib -D {deviceFamily} -overwrite +/intel_alm/common/mem_sim.v; " +
+						$"read_verilog -specify -lib -D {deviceFamily} -overwrite +/intel_alm/common/misc_sim.v; " +
+						$"read_verilog -specify -lib -D {deviceFamily} -overwrite -icells +/intel_alm/common/abc9_model.v; " +
+						"read_verilog -lib -overwrite +/intel/common/altpll_bb.v; " +
+						"read_verilog -lib -overwrite +/intel_alm/common/megafunction_bb.v;";
 				}
 
 				_logger.Error(
@@ -146,23 +146,23 @@ public class FpgaBbService : IFpgaBbService
 				break;
 
 			case "lattice":
-				return "read_verilog -lib -specify +/lattice/cells_sim.v +/lattice/cells_bb.v;";
+				return "read_verilog -lib -specify -overwrite +/lattice/cells_sim.v +/lattice/cells_bb.v;";
 
 			case "microchip":
-				return "read_verilog -lib -specify +/microchip/cells_sim.v;";
+				return "read_verilog -lib -specify -overwrite +/microchip/cells_sim.v;";
 
 			case "nanoxplore":
 				return
-					"read_verilog -lib -specify +/nanoxplore/cells_sim.v +/nanoxplore/cells_sim.v +/nanoxplore/cells_bb.v +/nanoxplore/cells_bb.v;";
+					"read_verilog -lib -specify -overwrite +/nanoxplore/cells_sim.v +/nanoxplore/cells_sim.v +/nanoxplore/cells_bb.v +/nanoxplore/cells_bb.v;";
 
 			case "nexus":
-				return "read_verilog -lib -specify +/nexus/cells_sim.v +/nexus/cells_xtra.v;";
+				return "read_verilog -lib -specify -overwrite +/nexus/cells_sim.v +/nexus/cells_xtra.v;";
 
 			case "quicklogic":
 				if (deviceFamily is "pp3" or "qlf_k6n10f")
 				{
 					return
-						$"read_verilog -lib -specify +/quicklogic/common/cells_sim.v +/quicklogic/{deviceFamily}/cells_sim.v;";
+						$"read_verilog -lib -specify -overwrite +/quicklogic/common/cells_sim.v +/quicklogic/{deviceFamily}/cells_sim.v;";
 				}
 
 				_logger.Error(
@@ -170,11 +170,11 @@ public class FpgaBbService : IFpgaBbService
 				break;
 
 			case "sf2":
-				return "read_verilog -lib +/sf2/cells_sim.v;";
+				return "read_verilog -lib -overwrite +/sf2/cells_sim.v;";
 
 			case "xilinx":
-				return "read_verilog -lib -specify +/xilinx/cells_sim.v; " +
-				       "read_verilog -lib +/xilinx/cells_xtra.v;";
+				return "read_verilog -lib -overwrite -specify +/xilinx/cells_sim.v; " +
+				       "read_verilog -lib -overwrite +/xilinx/cells_xtra.v;";
 
 			default:
 				_logger.Error("Unknown device manufacturer");


### PR DESCRIPTION
This PR implements a fix for #41. By using the `-nooverride` flag during the import of the device-specific primitive libraries, user-provided models are preserved (instead of being overwritten or the generation process erroring out). By preserving the user's definition, interface mismatches due to (potentially accidental) naming collisions between models are averted.