### PR TITLE
Adapt the netlist generation to the new interface in the GHDL extension

### DIFF
--- a/src/FEntwumS.NetlistViewer/FEntwumS.NetlistViewer.csproj
+++ b/src/FEntwumS.NetlistViewer/FEntwumS.NetlistViewer.csproj
@@ -25,14 +25,14 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="OneWare.Essentials" Version="1.0.10" Private="false" ExcludeAssets="runtime;Native">
+      <PackageReference Include="OneWare.Essentials" Version="1.0.19" Private="false" ExcludeAssets="runtime;Native">
               <PrivateAssets>all</PrivateAssets>
               <IncludeAssets>compile; build; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="OneWare.GhdlExtension" Version="1.0.0" Private="true">
+      <PackageReference Include="OneWare.GhdlExtension" Version="1.0.4" Private="true">
           <ExcludeAssets>runtime; Native</ExcludeAssets>
       </PackageReference>
-      <PackageReference Include="OneWare.UniversalFpgaProjectSystem" Version="1.0.10" Private="false" ExcludeAssets="runtime;Native">
+      <PackageReference Include="OneWare.UniversalFpgaProjectSystem" Version="1.0.19" Private="false" ExcludeAssets="runtime;Native">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>compile; build; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
+++ b/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using OneWare.Essentials.Models;
 using OneWare.Essentials.Services;
 using OneWare.ProjectSystem.Models;
+using OneWare.UniversalFpgaProjectSystem;
 using OneWare.UniversalFpgaProjectSystem.Models;
 
 namespace FEntwumS.NetlistViewer.Services;
@@ -54,7 +55,14 @@ public class NetlistGenerator : INetlistGenerator
 			Directory.CreateDirectory(outputDir);
 		}
 
-		return await ghdlService.SynthAsync(vhdlProject.FullPath, "verilog", outputDir);
+		if (vhdlProject.Root is UniversalFpgaProjectRoot root)
+		{
+			return await ghdlService.SynthAsync(root, "verilog", outputDir);
+		}
+		else
+		{
+			return false;
+		}
 	}
 
 	public async Task<bool> GenerateVerilogNetlistAsync(IProjectFile verilogProject)

--- a/tests/FEntwumS.NetlistViewer.UnitTests/FEntwumS.NetlistViewer.UnitTests.csproj
+++ b/tests/FEntwumS.NetlistViewer.UnitTests/FEntwumS.NetlistViewer.UnitTests.csproj
@@ -15,9 +15,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="OneWare.Essentials" Version="1.0.10" />
-      <PackageReference Include="OneWare.GhdlExtension" Version="1.0.0" />
-      <PackageReference Include="OneWare.UniversalFpgaProjectSystem" Version="1.0.10" />
+      <PackageReference Include="OneWare.Essentials" Version="1.0.19" />
+      <PackageReference Include="OneWare.GhdlExtension" Version="1.0.4" />
+      <PackageReference Include="OneWare.UniversalFpgaProjectSystem" Version="1.0.19" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The newest GHDL extension release has slightly modified the method signature for `GhdlService.SynthAsync()`. This PR adapts the netlist generation to the new interface, thereby enabling ongoing support for netlist generation of VHDL-based projects