### PR TITLE
Rework settings upgrade mechanism

### DIFF
--- a/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
+++ b/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
@@ -701,6 +701,10 @@ public class FEntwumSNetlistReaderFrontendModule : OneWareModuleBase
 		ServiceManager.GetService<ISettingsService>().RegisterSetting("Netlist Viewer", "Experimental",
 			FentwumSNetlistViewerSettingsHelper.AutomaticNetlistGenerationIntervalKey,
 			new SliderSetting("Automatic netlist generation interval (s)", 60.0d, 15.0d, 3600.0d, 5.0d));
+		
+		// These settings are not displayed to the user; They store internal extension state
+		ServiceManager.GetService<ISettingsService>().Register(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey, -1);
+		ServiceManager.GetService<ISettingsService>().Register(FentwumSNetlistViewerSettingsHelper.NetlistGenerationSettingsChangedKey, "");
 
 		ServiceManager.GetService<ILogger>().Log("Registered custom settings");
 	}

--- a/src/FEntwumS.NetlistViewer/Helpers/FentwumSNetlistViewerSettingsHelper.cs
+++ b/src/FEntwumS.NetlistViewer/Helpers/FentwumSNetlistViewerSettingsHelper.cs
@@ -14,7 +14,7 @@ public class FentwumSNetlistViewerSettingsHelper
 
 	#endregion
 
-	public static readonly string ExpectedSettingsVersion = "3";
+	public static readonly int ExpectedSettingsVersion = 4;
 
 	public static readonly string DataDirectory = Path.Combine(
 		Environment.GetFolderPath(

--- a/src/FEntwumS.NetlistViewer/Helpers/SettingsUpgrader.cs
+++ b/src/FEntwumS.NetlistViewer/Helpers/SettingsUpgrader.cs
@@ -8,10 +8,19 @@ public class SettingsUpgrader
 	public static bool NeedsUpgrade()
 	{
 		IStorageService storageService = ServiceManager.GetService<IStorageService>();
-		string currentSettingsVersion =
-			storageService.GetKeyValuePairValue(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey) ?? "0";
+		ISettingsService settingsService = ServiceManager.GetService<ISettingsService>();
+		int legacySettingsVersion =
+			int.Parse(storageService.GetKeyValuePairValue(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey) ?? "-1");
 
-		return currentSettingsVersion != FentwumSNetlistViewerSettingsHelper.ExpectedSettingsVersion;
+		if (settingsService.GetSettingValue<int>(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey) == -1)
+		{
+			settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey, legacySettingsVersion);
+		}
+
+		int currentSettingVersion =
+			settingsService.GetSettingValue<int>(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey);
+
+		return currentSettingVersion != FentwumSNetlistViewerSettingsHelper.ExpectedSettingsVersion;
 	}
 
 	public static async Task UpgradeSettingsIfNecessaryAsync()
@@ -21,9 +30,7 @@ public class SettingsUpgrader
 		IPaths paths = ServiceManager.GetService<IPaths>();
 		IProjectExplorerService projectExplorerService = ServiceManager.GetService<IProjectExplorerService>();
 		int currentSettingsVersion =
-			Convert.ToInt32(
-				storageService.GetKeyValuePairValue(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey) ??
-				"0");
+			settingsService.GetSettingValue<int>(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey);
 
 
 		if (currentSettingsVersion <= 0)
@@ -50,8 +57,11 @@ public class SettingsUpgrader
 			settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.AlwaysRegenerateNetlistsKey, false);
 		}
 
-		storageService.SetKeyValuePairValue(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey,
-			FentwumSNetlistViewerSettingsHelper.ExpectedSettingsVersion);
-		await storageService.SaveAsync();
+		if (currentSettingsVersion <= 3)
+		{
+			settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.AlwaysRegenerateNetlistsKey, true);
+		}
+
+		settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.FentwumsSettingVersionKey, FentwumSNetlistViewerSettingsHelper.ExpectedSettingsVersion);
 	}
 }

--- a/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
+++ b/src/FEntwumS.NetlistViewer/Services/NetlistGenerator.cs
@@ -177,20 +177,28 @@ public class NetlistGenerator : INetlistGenerator
 			}
 		}
 
-		string? storedSettingsChangedTime = _storageService.GetKeyValuePairValue(FentwumSNetlistViewerSettingsHelper
-			.NetlistGenerationSettingsChangedKey);
+		string storedSettingsChangedTime = _settingsService.GetSettingValue<string>(FentwumSNetlistViewerSettingsHelper.NetlistGenerationSettingsChangedKey);
 
-		// Date format "R" is the RFC1123 pattern
-		DateTime settingsChangedTime = DateTime.ParseExact(
-			storedSettingsChangedTime ?? DateTime.Now.ToString("R"), "R", new DateTimeFormatInfo());
-
-		if (storedSettingsChangedTime is null)
+		if (storedSettingsChangedTime.Length == 0)
 		{
-			_storageService.SetKeyValuePairValue(
-				FentwumSNetlistViewerSettingsHelper.NetlistGenerationSettingsChangedKey, DateTime.Now.ToString("R"));
-			_ = _storageService.SaveAsync();
+			storedSettingsChangedTime = DateTime.Now.ToUniversalTime().ToString("R");
+			_settingsService.SetSettingValue(FentwumSNetlistViewerSettingsHelper.NetlistGenerationSettingsChangedKey, storedSettingsChangedTime);
 		}
-		else if (netlistFile.LastWriteTimeUtc.CompareTo(settingsChangedTime.ToUniversalTime()) <= 0)
+
+		DateTime settingsChangedTime;
+		// Date format "R" is the RFC1123 pattern
+		try
+		{
+			settingsChangedTime = DateTime.ParseExact(
+				storedSettingsChangedTime, "R", new DateTimeFormatInfo());
+		}
+		catch (Exception e)
+		{
+			// Assume the netlist is outdated if an exception occurs
+			return (null, false);
+		}
+
+		if (netlistFile.LastWriteTimeUtc.CompareTo(settingsChangedTime.ToUniversalTime()) <= 0)
 		{
 			newNetlistNecessary = true;
 		}

--- a/src/FEntwumS.NetlistViewer/Services/StorageService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/StorageService.cs
@@ -18,6 +18,7 @@ public class StorageService : IStorageService
 
 	private static Dictionary<string, string> _storage = new Dictionary<string, string>();
 
+	[Obsolete("Deprecated")]
 	public async Task SaveAsync()
 	{
 		string path = FentwumSNetlistViewerSettingsHelper.DataFilePath;
@@ -50,6 +51,7 @@ public class StorageService : IStorageService
 		}
 	}
 
+	[Obsolete("Deprecated")]
 	public async Task LoadAsync()
 	{
 		string path = FentwumSNetlistViewerSettingsHelper.DataFilePath;
@@ -88,16 +90,19 @@ public class StorageService : IStorageService
 		}
 	}
 
+	[Obsolete("Deprecated")]
 	public void RegisterKeyValuePair(string key, string value)
 	{
 		_storage.TryAdd(key, value);
 	}
 
+	[Obsolete("Deprecated")]
 	public void RemoveKeyValuePair(string key)
 	{
 		_storage.Remove(key);
 	}
 
+	[Obsolete("Deprecated")]
 	public void SetKeyValuePairValue(string key, string value)
 	{
 		if (!_storage.ContainsKey(key))
@@ -110,11 +115,13 @@ public class StorageService : IStorageService
 		}
 	}
 
+	[Obsolete("Deprecated")]
 	public string? GetKeyValuePairValue(string key)
 	{
 		return _storage.TryGetValue(key, out var value) ? value : null;
 	}
 
+	[Obsolete("Deprecated")]
 	public bool KeyExists(string key)
 	{
 		return _storage.ContainsKey(key);


### PR DESCRIPTION
This PR reworks the settings upgrade mechanism to use OneWare-provided state storage mechanism instead of our StorageService. The StorageService is now considered deprecated and all usages have been migrated to use the OneWare-provided approach instead