### PR TITLE
Implement viewer for synthesized netlists

### DIFF
--- a/src/FEntwumS.NetlistViewer/Controls/NetlistControl.cs
+++ b/src/FEntwumS.NetlistViewer/Controls/NetlistControl.cs
@@ -219,6 +219,15 @@ public class NetlistControl : TemplatedControl, ICustomHitTest
     public static readonly StyledProperty<bool> FileLoadedProperty =
         AvaloniaProperty.Register<NetlistControl, bool>(nameof(FileLoaded));
 
+    public string ProjectRootFolder
+    {
+	    get => GetValue(ProjectRootFolderProperty);
+	    set => SetValue(ProjectRootFolderProperty, value);
+    }
+    
+    public static readonly  StyledProperty<string> ProjectRootFolderProperty =
+	    AvaloniaProperty.Register<NetlistControl, string>(nameof(ProjectRootFolder));
+
     #endregion
 
     public event ElementClickedEventHandler ElementClicked;
@@ -1211,11 +1220,19 @@ public class NetlistControl : TemplatedControl, ICustomHitTest
             line = vhdlLine;
         }
 
-        var ds = ServiceManager.GetService<IMainDockService>();
+        if (filename[0] != '/' && filename.Substring(1, 2) != ":\\")
+        {
+	        filename = Path.Combine(ProjectRootFolder, filename);
+        }
 
-        var document = await ds.OpenFileAsync(filename);
+        if (File.Exists(filename))
+        {
+	        var ds = ServiceManager.GetService<IMainDockService>();
 
-        (document as IEditor)?.JumpToLine((int)line);
+	        var document = await ds.OpenFileAsync(filename);
+
+	        (document as IEditor)?.JumpToLine((int)line);
+        }
     }
 
     private void NetlistControl_PointerMoved(object? sender, PointerEventArgs e)

--- a/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
+++ b/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
@@ -15,6 +15,7 @@ using OneWare.Essentials.Services;
 using OneWare.Essentials.ViewModels;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
+using OneWare.ProjectSystem.Models;
 using OneWare.UniversalFpgaProjectSystem.Services;
 
 namespace FEntwumS.NetlistViewer;
@@ -604,30 +605,71 @@ public class FEntwumSNetlistReaderFrontendModule : OneWareModuleBase
 			}
 			else if (selected is [IProjectFile { Extension: ".vhd" } vhdlFile])
 			{
+				string synthFilePath = Path.Combine(vhdlFile.Root.FullPath, "build", "synth.json");
+				
 				menuItems.Add(new MenuItemModel("NetlistViewer_CreateNetlist")
 				{
-					Header = $"View netlist for {vhdlFile.Header}",
+					Header = $"View RTL for {vhdlFile.Header}",
 					Command = new AsyncRelayCommand(() =>
 						ServiceManager.GetService<FrontendService>().CreateVhdlNetlistAsync(vhdlFile))
 				});
+
+				if (File.Exists(synthFilePath))
+				{
+					menuItems.Add(new MenuItemModel("NetlistViewer_ViewPostSynth")
+					{
+						Header = $"View Post-Synthesis Netlist for {vhdlFile.Header}",
+						Command = new AsyncRelayCommand(() =>
+							ServiceManager.GetService<FrontendService>().ShowViewerAsync(
+								new ProjectFile($"{synthFilePath}", vhdlFile.TopFolder!)))
+					});
+				}
 			}
 			else if (selected is [IProjectFile { Extension: ".v" } verilogFile])
 			{
+				string synthFilePath = Path.Combine(verilogFile.Root.FullPath, "build", "synth.json");
+				
 				menuItems.Add(new MenuItemModel("NetlistViewer_CreateVerilogNetlist")
 				{
 					Header = $"View netlist for {verilogFile.Header}",
 					Command = new AsyncRelayCommand(() =>
 						ServiceManager.GetService<FrontendService>().CreateVerilogNetlistAsync(verilogFile))
 				});
+
+				if (File.Exists(synthFilePath))
+				{
+					menuItems.Add(new MenuItemModel("NetlistViewer_ViewPostSynth")
+					{
+						Header = $"View Post-Synthesis Netlist for {verilogFile.Header}",
+						Command = new AsyncRelayCommand(() =>
+							ServiceManager.GetService<FrontendService>().ShowViewerAsync(
+								new ProjectFile($"{verilogFile.Root.FullPath}/build/synth.json",
+									verilogFile.TopFolder!)))
+					});
+				}
 			}
 			else if (selected is [IProjectFile { Extension: ".sv" } systemVerilogFile])
 			{
+				string synthFilePath = Path.Combine(systemVerilogFile.Root.FullPath, "build", "synth.json");
+				
 				menuItems.Add(new MenuItemModel("NetlistViewer_CreateSystemVerilogNetlist")
 				{
 					Header = $"View netlist for {systemVerilogFile.Header}",
 					Command = new AsyncRelayCommand(() =>
 						ServiceManager.GetService<FrontendService>().CreateSystemVerilogNetlistAsync(systemVerilogFile))
 				});
+
+				if (File.Exists(synthFilePath))
+				{
+					menuItems.Add(new MenuItemModel("NetlistViewer_ViewPostSynth")
+					{
+						Header = $"View Post-Synthesis Netlist for {systemVerilogFile.Header}",
+						Command = new AsyncRelayCommand(() =>
+							ServiceManager.GetService<FrontendService>().ShowViewerAsync(
+								new ProjectFile($"{systemVerilogFile.Root.FullPath}/build/synth.json",
+									systemVerilogFile.TopFolder!)))
+					});
+				}
 			}
 		});
 

--- a/src/FEntwumS.NetlistViewer/Services/FrontendService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/FrontendService.cs
@@ -671,6 +671,7 @@ public class FrontendService : IFrontendService
 
 		_dockService.Show(vm, DockShowLocation.Document);
 		_dockService.InitializeContent();
+		vm.ProjectRootFolder = json.Root.RootFolderPath;
 		vm.NetlistId = currentNetlist;
 		await vm.OpenFileImplAsync();
 

--- a/src/FEntwumS.NetlistViewer/Services/FrontendService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/FrontendService.cs
@@ -594,6 +594,13 @@ public class FrontendService : IFrontendService
 		{
 			{ new StreamContent(jsonFileStream), "file", json.Name }
 		};
+		
+		bool success = await StartBackendIfNotStartedAsync() && await ServerStartedAsync();
+
+		if (!success)
+		{
+			return;
+		}
 
 		ApplicationProcess waitForBackendProc =
 			_applicationStateService.AddState("Layouting in progress", AppState.Loading);
@@ -638,7 +645,7 @@ public class FrontendService : IFrontendService
 		{
 			_logger.Log($"Found cross-compiled Verilog at {ccVhdlFilePath}");
 			
-			bool success = await ServiceManager.GetService<ICcVhdlFileIndexService>()
+			success = await ServiceManager.GetService<ICcVhdlFileIndexService>()
 				.IndexFileAsync(ccVhdlFilePath, combinedHash);
 
 			if (success)

--- a/src/FEntwumS.NetlistViewer/Services/FrontendService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/FrontendService.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Logging;
 using OneWare.Essentials.Helpers;
 using OneWare.Essentials.PackageManager;
 using OneWare.Essentials.PackageManager.Compatibility;
+using OneWare.UniversalFpgaProjectSystem.Models;
 using StreamContent = System.Net.Http.StreamContent;
 
 namespace FEntwumS.NetlistViewer.Services;
@@ -640,6 +641,14 @@ public class FrontendService : IFrontendService
 
 		// create code index for cross-compiled VHDL
 		string ccVhdlFilePath = FentwumSNetlistViewerSettingsHelper.GetCcVhdlFilePath(json);
+
+		if (Path.GetFileName(json.Name) == "synth.json")
+		{
+			if (json.Root is UniversalFpgaProjectRoot root)
+			{
+				ccVhdlFilePath = Path.Combine(root.RootFolderPath, "build", "gen_verilog", root.TopEntity! + ".v");
+			}
+		}
 
 		if (File.Exists(ccVhdlFilePath))
 		{

--- a/src/FEntwumS.NetlistViewer/ViewModels/FrontendViewModel.cs
+++ b/src/FEntwumS.NetlistViewer/ViewModels/FrontendViewModel.cs
@@ -126,8 +126,20 @@ public class FrontendViewModel : ExtendedTool
 			OnPropertyChanged();
 		}
 	}
-
+	
 	[DataMember] private UInt64 netlistId { get; set; }
+
+	public string ProjectRootFolder
+	{
+		get => projectRootFolder;
+		set
+		{
+			projectRootFolder = value;
+			OnPropertyChanged();
+		}
+	}
+	
+	[DataMember] private string projectRootFolder { get; set; }
 
 	private bool fileLoaded { get; set; }
 

--- a/src/FEntwumS.NetlistViewer/Views/FrontendView.axaml
+++ b/src/FEntwumS.NetlistViewer/Views/FrontendView.axaml
@@ -39,7 +39,8 @@
                                      ClickedElementPath="{Binding ClickedElementPath}" NetlistID="{Binding NetlistId}"
                                      FileLoaded="{Binding FileLoaded}"
                                      x:Name="NetlistView"
-                                     FontFamily="{StaticResource MartianMono}">
+                                     FontFamily="{StaticResource MartianMono}"
+                                     ProjectRootFolder="{Binding ProjectRootFolder}">
             </controls:NetlistControl>
             
             <Button Background="{DynamicResource ThemeBackgroundBrush}" Padding="5" CornerRadius="3"


### PR DESCRIPTION
As requested in #42, this PR implements basic support for synthesized netlists. The viewer will look for the synthesized netlist in the default location and allow for viewing iff it is found there.

While the synthesized netlist lacks a lot of source attributions compared to the RTL netlist, jump-to-source has been implemented on a best effort basis. This includes support for jumping to VHDL sources.