### PR TITLE
Don't fail on excluded files

### DIFF
--- a/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
+++ b/src/FEntwumS.NetlistViewer/FEntwumSNetlistReaderFrontendModule.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using OneWare.ProjectSystem.Models;
 using OneWare.UniversalFpgaProjectSystem.Services;
+using OneWare.UniversalFpgaProjectSystem.Models;
 
 namespace FEntwumS.NetlistViewer;
 
@@ -606,23 +607,27 @@ public class FEntwumSNetlistReaderFrontendModule : OneWareModuleBase
 			else if (selected is [IProjectFile { Extension: ".vhd" } vhdlFile])
 			{
 				string synthFilePath = Path.Combine(vhdlFile.Root.FullPath, "build", "synth.json");
-				
-				menuItems.Add(new MenuItemModel("NetlistViewer_CreateNetlist")
-				{
-					Header = $"View RTL for {vhdlFile.Header}",
-					Command = new AsyncRelayCommand(() =>
-						ServiceManager.GetService<FrontendService>().CreateVhdlNetlistAsync(vhdlFile))
-				});
 
-				if (File.Exists(synthFilePath))
+				if (vhdlFile is { Root: UniversalFpgaProjectRoot root, Icon.Overlays.Length: > 0 } && !root.IsTestBench(vhdlFile.FullPath))
 				{
-					menuItems.Add(new MenuItemModel("NetlistViewer_ViewPostSynth")
+					
+					menuItems.Add(new MenuItemModel("NetlistViewer_CreateNetlist")
 					{
-						Header = $"View Post-Synthesis Netlist for {vhdlFile.Header}",
+						Header = $"View RTL for {vhdlFile.Header}",
 						Command = new AsyncRelayCommand(() =>
-							ServiceManager.GetService<FrontendService>().ShowViewerAsync(
-								new ProjectFile($"{synthFilePath}", vhdlFile.TopFolder!)))
+							ServiceManager.GetService<FrontendService>().CreateVhdlNetlistAsync(vhdlFile))
 					});
+					
+					if (File.Exists(synthFilePath))
+					{
+						menuItems.Add(new MenuItemModel("NetlistViewer_ViewPostSynth")
+						{
+							Header = $"View Post-Synthesis Netlist for {vhdlFile.Header}",
+							Command = new AsyncRelayCommand(() =>
+								ServiceManager.GetService<FrontendService>().ShowViewerAsync(
+									new ProjectFile($"{synthFilePath}", vhdlFile.TopFolder!)))
+						});
+					}
 				}
 			}
 			else if (selected is [IProjectFile { Extension: ".v" } verilogFile])
@@ -631,12 +636,12 @@ public class FEntwumSNetlistReaderFrontendModule : OneWareModuleBase
 				
 				menuItems.Add(new MenuItemModel("NetlistViewer_CreateVerilogNetlist")
 				{
-					Header = $"View netlist for {verilogFile.Header}",
+					Header = $"View RTL for {verilogFile.Header}",
 					Command = new AsyncRelayCommand(() =>
 						ServiceManager.GetService<FrontendService>().CreateVerilogNetlistAsync(verilogFile))
 				});
 
-				if (File.Exists(synthFilePath))
+				if (verilogFile is { Root: UniversalFpgaProjectRoot root, Icon.Overlays.Length: > 0 } && !root.IsTestBench(verilogFile.FullPath) && File.Exists(synthFilePath))
 				{
 					menuItems.Add(new MenuItemModel("NetlistViewer_ViewPostSynth")
 					{
@@ -654,12 +659,12 @@ public class FEntwumSNetlistReaderFrontendModule : OneWareModuleBase
 				
 				menuItems.Add(new MenuItemModel("NetlistViewer_CreateSystemVerilogNetlist")
 				{
-					Header = $"View netlist for {systemVerilogFile.Header}",
+					Header = $"View RTL for {systemVerilogFile.Header}",
 					Command = new AsyncRelayCommand(() =>
 						ServiceManager.GetService<FrontendService>().CreateSystemVerilogNetlistAsync(systemVerilogFile))
 				});
 
-				if (File.Exists(synthFilePath))
+				if (systemVerilogFile is { Root: UniversalFpgaProjectRoot root, Icon.Overlays.Length: > 0 } && !root.IsTestBench(systemVerilogFile.FullPath) && File.Exists(synthFilePath))
 				{
 					menuItems.Add(new MenuItemModel("NetlistViewer_ViewPostSynth")
 					{

--- a/src/FEntwumS.NetlistViewer/Services/YosysService.cs
+++ b/src/FEntwumS.NetlistViewer/Services/YosysService.cs
@@ -1,4 +1,5 @@
-﻿using FEntwumS.NetlistViewer.Helpers;
+﻿using Avalonia.Media;
+using FEntwumS.NetlistViewer.Helpers;
 using Microsoft.Extensions.Logging;
 using OneWare.Essentials.Models;
 using OneWare.Essentials.Services;
@@ -75,6 +76,13 @@ public class YosysService : IYosysService
 
 			verilogFileList.AddRange(verilogFiles);
 			systemVerilogFileList.AddRange(systemVerilogFiles);
+		}
+
+		if (verilogFileList.Count == 0 && systemVerilogFileList.Count == 0)
+		{
+			verilogFileList.Add(file.FullPath);
+			ServiceManager.GetService<ILogger>().Warning("No files where included for netlist generation. This is due to all files being either marked as testbenches or as excluded from compilation", null, true);
+			ServiceManager.GetService<ILogger>().Log("Including the selected file and proceeding", true, Brushes.White);
 		}
 
 		List<string> yosysArgs =


### PR DESCRIPTION
Fixes #40 by implicitly including the selected file in the netlist generation. Additionally, a warning message is printed to the output window informing the user of the problem and the applied workaround